### PR TITLE
Improve cta 1dc validation scripts

### DIFF
--- a/validation/cta-1dc/README.md
+++ b/validation/cta-1dc/README.md
@@ -19,6 +19,17 @@ the following test cases were chosen for the validation:
 
 Param not yet relevant, needs to add extra sources on top of J1702 to have a good model
 
+## Execution
+
+To run a all analyses use
+
+    python make.py run-analyses all 
+    
+To run the analysis for a specific source:
+
+    python make.py run-analyses 'cas_a'
+
+
 ## 1DC model
 
 

--- a/validation/cta-1dc/config_template.yaml
+++ b/validation/cta-1dc/config_template.yaml
@@ -1,48 +1,41 @@
-general:
-    outdir: {tag}
-    logging:
-      level: INFO
-
 observations:
-    datastore: $CTADATA/index/gps/
-    filters:
-        - filter_type: sky_circle
-          frame: galactic
-          lon: {lon}
-          lat: {lat}
-          radius: {radius}
-          border: 1 deg
+    datastore: $GAMMAPY_DATA/cta-1dc/index/gps/
+    obs_cone:
+      frame: galactic
+      lon: {lon}
+      lat: {lat}
+      radius: {radius}
 
 datasets:
-    dataset-type: MapDataset
-    stack-datasets: true
-    offset-max: 4 deg
+    type: 3d
+    stack: true
     geom:
-        skydir:
-          - {lon_deg}
-          - {lat_deg}
-        width: [2, 2]
-        binsz: 0.02
-        coordsys: GAL
-        proj: TAN
+        wcs:
+            skydir:
+              frame: galactic
+              lon: {lon}
+              lat: {lat}
+            binsize: 0.02 deg
+            fov:
+              width: 2 deg
+              height: 2 deg
+        selection:
+            offset_max: 4 deg
         axes:
-          - name: energy
-            lo_bnd: {emin_tev}
-            hi_bnd: {emax_tev}
-            nbin: {nbin}
-            interp: log
-            node_type: edges
-            unit: TeV
+            energy:
+              min: {emin}
+              max: {emax}
+              nbins: {nbin}
+    map_selection: ['counts', 'exposure', 'background', 'psf', 'edisp']
+
 
 fit:
     fit_range:
         min: {emin}
         max: {emax}
 
-flux-points:
-    fp_binning:
-        lo_bnd: {emin_tev}
-        hi_bnd: {emax_tev}
-        interp: log
-        nbin: {fp_nbin}
-        unit: TeV
+flux_points:
+    energy:
+        min: {emin}
+        max: {emax}
+        nbins: {fp_nbin}

--- a/validation/cta-1dc/make.py
+++ b/validation/cta-1dc/make.py
@@ -6,12 +6,9 @@ from pathlib import Path
 import yaml
 import click
 import warnings
-import astropy.units as u
-from astropy.coordinates import Angle
 from astropy.table import Table
 from gammapy.analysis import Analysis, AnalysisConfig
 from gammapy.modeling.models import SkyModels
-
 
 log = logging.getLogger(__name__)
 
@@ -46,6 +43,7 @@ def cli(log_level, show_warnings):
 
     if not show_warnings:
         warnings.simplefilter("ignore")
+
 
 @cli.command("run-analyses", help="Run Gammapy validation: CTA 1DC")
 @click.argument("targets", type=click.Choice(list(AVAILABLE_TARGETS) + ["all"]))
@@ -128,12 +126,11 @@ def analysis_3d_summary(target):
     pars.remove("reference")  # need to find a better way to handle this
 
     for par in pars:
-
         ref = ref_model.parameters[par].value
         value = tab.loc[par]["value"]
         name = tab.loc[par]["name"]
         error = tab.loc[par]["error"]
-        comp_tab.add_row([name, ref, f"{value}±{error}"],)
+        comp_tab.add_row([name, ref, f"{value}±{error}"])
 
     path = f"{target}/README.md"
     comp_tab.write(path, format="ascii.html", overwrite=True)

--- a/validation/cta-1dc/make.py
+++ b/validation/cta-1dc/make.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 import yaml
 import click
+import warnings
 import astropy.units as u
 from astropy.coordinates import Angle
 from astropy.table import Table
@@ -14,7 +15,7 @@ from gammapy.modeling.models import SkyModels
 
 log = logging.getLogger(__name__)
 
-AVAILABLE_SOURCES = ["cas_a", "hess_J1702"]
+AVAILABLE_TARGETS = ["cas_a", "hess_J1702"]
 
 
 def get_config(target):
@@ -22,17 +23,37 @@ def get_config(target):
     return config[target]
 
 
-# TODO
-# @cli.command("run", help="Run 1dc analysis validation")
-# @click.argument("targets", type=click.Choice(list(AVAILABLE_SOURCES) + ["all"]))
+@click.group()
+@click.option(
+    "--log-level",
+    default="info",
+    type=click.Choice(["debug", "info", "warning", "error", "critical"]),
+)
+@click.option("--show-warnings", is_flag=True, help="Show warnings?")
+def cli(log_level, show_warnings):
+    """
+    Run validation of DL3 data analysis.
+    """
+    levels = dict(
+        debug=logging.DEBUG,
+        info=logging.INFO,
+        warning=logging.WARNING,
+        error=logging.ERROR,
+        critical=logging.CRITICAL,
+    )
+    logging.basicConfig(level=levels[log_level])
+    log.setLevel(level=levels[log_level])
 
+    if not show_warnings:
+        warnings.simplefilter("ignore")
 
-def cli():
-    targets = "all"
+@cli.command("run-analyses", help="Run Gammapy validation: CTA 1DC")
+@click.argument("targets", type=click.Choice(list(AVAILABLE_TARGETS) + ["all"]))
+def run_analyses(targets):
     if targets == "all":
-        targets = ["cas_a", "hess_j1702"]
+        targets = list(AVAILABLE_TARGETS)
     else:
-        targets = targets.split(",")
+        targets = [targets]
 
     for target in targets:
         analysis_3d(target)
@@ -49,16 +70,10 @@ def analysis_3d_data_reduction(target):
     log.info(f"analysis_3d_data_reduction: {target}")
 
     opts = get_config(target)
-    # TODO: remove this once Gammapy config is more uniform
-    opts["emin_tev"] = u.Quantity(opts["emin"]).to_value("TeV")
-    opts["emax_tev"] = u.Quantity(opts["emax"]).to_value("TeV")
-    opts["lon_deg"] = Angle(opts["lon"]).deg
-    opts["lat_deg"] = Angle(opts["lat"]).deg
 
     txt = Path("config_template.yaml").read_text()
     txt = txt.format_map(opts)
-    config = yaml.safe_load(txt)
-    config = AnalysisConfig(config)
+    config = AnalysisConfig.from_yaml(txt)
 
     analysis = Analysis(config)
     analysis.get_observations()
@@ -108,7 +123,6 @@ def analysis_3d_summary(target):
     dt = "U30"
     comp_tab = Table(names=("Param", "DC1 Ref", "gammapy 3d"), dtype=[dt, dt, dt])
 
-    path = f"{target}/reference/dc1_model_3d.yaml"
     ref_model = SkyModels.from_yaml(f"{target}/reference/dc1_model_3d.yaml")
     pars = ref_model.parameters.names
     pars.remove("reference")  # need to find a better way to handle this


### PR DESCRIPTION
As requested by @facero, I implemeted the CLI for the CTA 1DC validation scripts. I also updated the script to the latest master.

**Warning**: I don't have access to the [full CTA 1DC dataset](https://forge.in2p3.fr/projects/data-challenge-1-dc-1/wiki#Data-access), so I couldn't run the script to test if it is still OK or it is broken. It starts running, which is a good sign, but then it stops because of course it can't select any observation. Please, someone with access to the data could try to run it before merging? Use `python make.py run-analyses all`