### PR TITLE
Fix bug in light curve benchmarks

### DIFF
--- a/benchmarks/lightcurve_1d.py
+++ b/benchmarks/lightcurve_1d.py
@@ -107,7 +107,8 @@ def fit_lc(datasets):
     for dataset in datasets:
         dataset.models = model
     fit = Fit(datasets)
-    result = fit.optimize()
+    result = fit.run()
+    print(result)
     print(result.parameters.to_table())
 
 

--- a/benchmarks/spectrum_1d.py
+++ b/benchmarks/spectrum_1d.py
@@ -95,6 +95,7 @@ def data_fit(stacked):
     # Data fitting
     fit = Fit(stacked)
     result = fit.run(optimize_opts={"print_level": 1})
+    print(result.success)
 
 
 def flux_point(stacked):


### PR DESCRIPTION
The light curve benchmarks were not computing the covariance. This is now fixed

@Bultako : The warning in the spectral benchmarks is OK. It happens in the flux point computation for the highest energy bins.