### PR TITLE
Do not set linear scale for y axis for lightcurve validation plot

### DIFF
--- a/validation/lightcurve/make.py
+++ b/validation/lightcurve/make.py
@@ -251,12 +251,11 @@ def make_summary(types):
         model = define_model_1d()
 
         lc = FluxPoints.read(path, format="lightcurve", reference_model=model)
-        lc.plot(ax=ax, label=type, sed_type="flux", markersize=0)
+        lc.plot(ax=ax, label=type, sed_type="flux")
 
     lc_ref = read_ref_lightcurve()
-    lc_ref.plot(ax=ax, label='ref', alpha=0.2, sed_type="flux", markersize=0)
+    lc_ref.plot(ax=ax, label='ref', alpha=0.2, sed_type="flux")
 
-    ax.set_yscale("linear")
     plt.legend()
 
 


### PR DESCRIPTION
I think it is just a plotting issue. Removing the linear scale makes the light curve point appear clearly again. 

Closes #163 